### PR TITLE
Increase selection background contrast vs. text

### DIFF
--- a/ayu-light.icls
+++ b/ayu-light.icls
@@ -2,7 +2,7 @@
   <colors>
     <option name="CONSOLE_BACKGROUND_KEY" value="FAFAFA" />
     <option name="INDENT_GUIDE" value="D9DBDD" />
-    <option name="SELECTION_BACKGROUND" value="E9F2F8" />
+    <option name="SELECTION_BACKGROUND" value="0C9EFF" />
     <option name="CARET_ROW_COLOR" value="F3F3F3" />
     <option name="WHITESPACES" value="D9DBDD" />
     <option name="CARET_COLOR" value="FF8F40" />


### PR DESCRIPTION
After importing to my editor, I noticed selected text was difficult to read due to little contrast between the selection background and the selected text.

This change shifts the selection background from an extremely pale blue to a bright but much darker blue so the light color of the selected text is much more visible and readable.